### PR TITLE
Issue 1: improving get item by UUID

### DIFF
--- a/src/Playlist.php
+++ b/src/Playlist.php
@@ -148,9 +148,24 @@ class Playlist
      */
     public function getItemsByUuid(array $uuids) : array
     {
-        $search = $this->search();
-        $search->condition('uuid', $uuids, 'IN');
-        return $search->find();
+        $results = [];
+        $aimingFor = count($uuids);
+
+        foreach ($this->items as $position => $item) {
+            if (!$item) {
+                continue;
+            }
+
+            if (in_array($item->uuid, $uuids)) {
+                $results[ $position ] = $item;
+            }
+
+            if (count($results) == $aimingFor) {
+                break;
+            }
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/PlaylistGetTest.php
+++ b/tests/PlaylistGetTest.php
@@ -53,4 +53,13 @@ final class PlaylistGetTest extends Base
 
         $this->assertEquals('Over the hills and far away', $lastItem->title);
     }
+
+    public function testGetItemByUuid() 
+    {
+        $playlist = new Playlist('tests/template.dpls');
+
+        $item = $playlist->getItemByUuid('008540f5-cf34-41ec-8b3f-9e1639695370');
+
+        $this->assertEquals('Let\'s go sunning', $item->title);
+    }
 }


### PR DESCRIPTION
## Overview
`Playlist::getItemByUuid()` rely on the search feature to return the specified items.

This means that even if the item is at the very beginning of the playlist, the entire of it will still be traversed, which is not optimal.

## Solution
Updated the method to stop iterating through the file once it has found the desired item.

## Issue
[issue-1](https://github.com/adinan-cenci/descriptive-playlist/issues/1)