### PR TITLE
issue-5: Playlist::deletePosition() deletes the wrong playlist item

### DIFF
--- a/src/Playlist.php
+++ b/src/Playlist.php
@@ -368,7 +368,7 @@ class Playlist
     public function deletePosition(int $position, &$item = null): bool
     {
         if ($item = $this->getItem($position)) {
-            $this->jsonLines->deleteObject($position);
+            $this->jsonLines->deleteObject($position + 1);
             return true;
         }
 


### PR DESCRIPTION
## Overview
Using `Playlist::deletePosition()` does not delete the intended item, but the one before.

## Issue
[Click here](https://github.com/Wishgranter-project/descriptive-playlist/issues/5)